### PR TITLE
Disable log rotation by default, ensure logrotate compatibility

### DIFF
--- a/simpledaemonlog/daemonarguments.py
+++ b/simpledaemonlog/daemonarguments.py
@@ -16,9 +16,9 @@ def add_daemon_arguments(parser):
     parser.add_argument("-d", dest="daemon", action="store_true", help="Daemon mode, no logging to console.")
     parser.add_argument("--logdir", default=None, help="Folder where logfiles should be stored.")
     parser.add_argument("--colorlog", default=False, type=arg_str2bool, help="Color logs for terminal output.")
-    parser.add_argument("--rotate-count", default=0, type=int, help="Enable log rotation, keep so many old log files. If 0, log rotation is disabled.")
-    parser.add_argument("--rotate-unit", default="W6", type=str, help="When log rotation is enabled, select this time unit ('S':secs, 'M':mins, 'H':hours, 'D':days, 'W0'-'W6':weekday, 'midnight')")
-    parser.add_argument("--rotate-interval", default="1", type=int, help="When log rotation is enabled, allow this many time units to elapse before doing the rotation (not used when weekday rotation is selected)")
+    parser.add_argument("--rotate_count", default=0, type=int, help="Enable log rotation, keep so many old log files. If 0, log rotation is disabled.")
+    parser.add_argument("--rotate_unit", default="W6", type=str, help="When log rotation is enabled, select this time unit ('S':secs, 'M':mins, 'H':hours, 'D':days, 'W0'-'W6':weekday, 'midnight')")
+    parser.add_argument("--rotate_interval", default="1", type=int, help="When log rotation is enabled, allow this many time units to elapse before doing the rotation (not used when weekday rotation is selected)")
 
 
 def setup_daemon(args, name):
@@ -26,7 +26,7 @@ def setup_daemon(args, name):
         logsetup.setup_console(color=args.colorlog)
 
     if args.logdir is not None:
-        logsetup.setup_file(name, logdir=args.logdir, backupCount=args.rotate-count, backupInterval=args.rotate-interval, backupIntervalUnit=args.rotate-unit)
+        logsetup.setup_file(name, logdir=args.logdir, backups=args.rotate_count, backupInterval=args.rotate_interval, backupIntervalUnit=args.rotate_unit)
     elif args.daemon:
         print "WARNING Logging not configured!"
         print args

--- a/simpledaemonlog/daemonarguments.py
+++ b/simpledaemonlog/daemonarguments.py
@@ -16,6 +16,9 @@ def add_daemon_arguments(parser):
     parser.add_argument("-d", dest="daemon", action="store_true", help="Daemon mode, no logging to console.")
     parser.add_argument("--logdir", default=None, help="Folder where logfiles should be stored.")
     parser.add_argument("--colorlog", default=False, type=arg_str2bool, help="Color logs for terminal output.")
+    parser.add_argument("--rotate-count", default=0, type=int, help="Enable log rotation, keep so many old log files. If 0, log rotation is disabled.")
+    parser.add_argument("--rotate-unit", default="W6", type=str, help="When log rotation is enabled, select this time unit ('S':secs, 'M':mins, 'H':hours, 'D':days, 'W0'-'W6':weekday, 'midnight')")
+    parser.add_argument("--rotate-interval", default="1", type=int, help="When log rotation is enabled, allow this many time units to elapse before doing the rotation (not used when weekday rotation is selected)")
 
 
 def setup_daemon(args, name):
@@ -23,7 +26,7 @@ def setup_daemon(args, name):
         logsetup.setup_console(color=args.colorlog)
 
     if args.logdir is not None:
-        logsetup.setup_file(name, logdir=args.logdir)
+        logsetup.setup_file(name, logdir=args.logdir, backupCount=args.rotate-count, backupInterval=args.rotate-interval, backupIntervalUnit=args.rotate-unit)
     elif args.daemon:
         print "WARNING Logging not configured!"
         print args

--- a/simpledaemonlog/logsetup.py
+++ b/simpledaemonlog/logsetup.py
@@ -85,7 +85,7 @@ def setup_console(level=logging.NOTSET, fs=DEFAULT_FORMAT_STRING, settings=None,
         log.debug("logging config loaded from {:s}".format(loaded))
 
 
-def setup_file(application_name, logdir="log", level=logging.NOTSET, fs=DEFAULT_FORMAT_STRING, settings=None, backups=8):
+def setup_file(application_name, logdir="log", level=logging.NOTSET, fs=DEFAULT_FORMAT_STRING, settings=None, backups=8, backupInterval=1, backupIntervalUnit="W6"):
     """
      Directs printf to file with INFO level.
     """
@@ -102,9 +102,10 @@ def setup_file(application_name, logdir="log", level=logging.NOTSET, fs=DEFAULT_
     logfilepath = os.path.join(logdir, logfilename)
     loglinkpath = os.path.join(logdir, loglatest)
     if backups:
-        logfile = logging.handlers.TimedRotatingFileHandler(logfilepath, when="W6", backupCount=backups)
+        logfile = logging.handlers.TimedRotatingFileHandler(logfilepath, backupCount=backups, when=backupIntervalUnit, interval=backupInterval)
     else:
-        logfile = logging.FileHandler(logfilepath)
+        # Expect logrotate to pull the file out from underneath us
+        logfile = logging.WatchedFileHandler(logfilepath)
 
     if hasattr(os, "symlink"):
         if os.path.islink(loglinkpath):

--- a/simpledaemonlog/logsetup.py
+++ b/simpledaemonlog/logsetup.py
@@ -105,7 +105,7 @@ def setup_file(application_name, logdir="log", level=logging.NOTSET, fs=DEFAULT_
         logfile = logging.handlers.TimedRotatingFileHandler(logfilepath, backupCount=backups, when=backupIntervalUnit, interval=backupInterval)
     else:
         # Expect logrotate to pull the file out from underneath us
-        logfile = logging.WatchedFileHandler(logfilepath)
+        logfile = logging.handlers.WatchedFileHandler(logfilepath)
 
     if hasattr(os, "symlink"):
         if os.path.islink(loglinkpath):


### PR DESCRIPTION
Don't rotate logs unless specified so by cmdline arguments. 
Using WatchedFileHandler ensures that we create a shiny new log file when logrotate rotates our old one.
